### PR TITLE
Fix documentation to use room id, not room address

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Once this feature is implemented on Synapse side (https://github.com/matrix-org/
 Plugin will strip away encryption from newly created rooms.
 In addition the plugin will filter out events for enabling encryption on room based on the server:
   - deny_encryption_for_users_of: if the event sender is on the server in the list (i.e. @user:example.org)
-  - deny_encryption_for_rooms_of: if the room is on the server in the list (i.e. #room:example.org)
+  - deny_encryption_for_rooms_of: if the room is on the server in the list (i.e. !room:example.org)
 
 In your `homeserver.yaml`:
 

--- a/matrix_e2ee_filter.py
+++ b/matrix_e2ee_filter.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 #   Plugin will strip away encryption from newly created rooms.
 #   In addition the plugin will filter out events for enabling encryption on room based on the server:
 #     - deny_encryption_for_users_of: if the event sender is on the server in the list (i.e. @user:example.org)
-#     - deny_encryption_for_rooms_of: if the room is on the server in the list (i.e. #room:example.org)
+#     - deny_encryption_for_rooms_of: if the room is on the server in the list (i.e. !room:example.org)
 
 # modules:
 #   - module: "matrix_e2ee_filter.EncryptedRoomFilter"


### PR DESCRIPTION
Looking at the filtering source code, checking is done against the room
id (e.g. `!room:example.org`), not against the address of the room
(`#room:example.org`). It works for rooms without address aliases.