### PR TITLE
Patch power levels on room creation

### DIFF
--- a/matrix_e2ee_filter.py
+++ b/matrix_e2ee_filter.py
@@ -37,6 +37,8 @@ class EncryptedRoomFilter:
 
 
     async def check_event_for_spam(self, event: "synapse.events.EventBase") -> Union[bool, str]:
+        # This is probably unnecessary if m.room.power_levels are set correctly
+        # Let's keep it just in case
         event_dict = event.get_dict()
         try:
             event_type = event_dict.get('type', None)
@@ -59,10 +61,47 @@ class EncryptedRoomFilter:
     async def on_create_room(self, requester: "synapse.types.Requester", request_content: dict, is_requester_admin: bool,) -> None:
         # Cut out encryption setting for the room, force room to be unencrypted
         # Note that this still doesn't block users from enabling encryption at a later stage
+
         filtered_initial_state = []
         for event in request_content.get('initial_state', []):
-            if event['type'] not in ['m.room.encryption']:
-                filtered_initial_state.append(event)
+            if event['type'] in ['m.room.encryption', 'm.room.power_levels']:
+                logger.info('Stripped "%s" from %s', event['type'], request_content.get('name', ''))
             else:
-                logger.info('Stripped away encryption request from %s', request_content.get('name', ''))
+                filtered_initial_state.append(event)
+
+        # Build the miinimalistic power m.room.power_levels:
+        #
+        # Handler `on_create_room` is called early in the room creation flow, before inviting users: 
+        # https://github.com/matrix-org/synapse/blob/develop/synapse/handlers/room.py#L686-L690
+        #
+        # Power levels are populated/generated later in the room creation flow. To make sure initial state is correct
+        # we need to mimic the server defaults. Defaults takes from here:
+        # https://github.com/matrix-org/synapse/blob/develop/synapse/handlers/room.py#L1015-L1035
+        requester_user_id = requester.user.to_string()
+        new_power_levels = {
+            'type': 'm.room.power_levels',
+            'sender': requester_user_id,
+            'content': {
+                'users': { requester_user_id: 100 },
+                'users_default': 0,
+                'events': {
+                    'm.room.name': 50,
+                    'm.room.power_levels': 100,
+                    'm.room.history_visibility': 100,
+                    'm.room.canonical_alias': 50,
+                    'm.room.avatar': 50,
+                    'm.room.tombstone': 100,
+                    'm.room.server_acl': 100,
+                    'm.room.encryption': 150
+                },
+                'events_default': 0,
+                'state_default': 50,
+                'ban': 50,
+                'kick': 50,
+                'redact': 50,
+                'invite': 0,
+                'historical': 100
+            }
+        }
+        filtered_initial_state.append(new_power_levels)
         request_content['initial_state'] = filtered_initial_state


### PR DESCRIPTION
Fixes https://github.com/digitalentity/matrix_encryption_disabler/issues/3

This now works similar to https://github.com/fhirfactory/pegacorn-communicate-roomserver/pull/7, but still keeps encryption from being enabled from the start during room creation and filters the encryption events just to be safe.

If federated servers and clients respect permissions room encryption should never be enabled even if the room is federated.

@spantaleev you might want to test this change and make sure it works with your ansible playbooks (no reason why it shouldn't though).