### PR TITLE
Patch the 'm.room.power_levels' event if present instead of completely overwriting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Plugin will strip away encryption from newly created rooms.
 
 If `patch_power_levels` option is set to `True` the plugin will additionally patch the `m.room.power_levels` event 
 and set the required power level for enabling encryption to 150 which is higher than the room creator level (100), 
-effectively preventing anybody from enabling the encryption. 
+effectively preventing anybody (locally or over federation) from enabling encryption for the lifetime of rooms created this way (irreversible).
 
 In addition the plugin will filter out events for enabling encryption on room based on the server:
   - deny_encryption_for_users_of: if the event sender is on the server in the list (i.e. @user:example.org)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Once this feature is implemented on Synapse side (https://github.com/matrix-org/
 ### Example config:
 
 Plugin will strip away encryption from newly created rooms.
+
+If `patch_power_levels` option is set to `True` the plugin will additionally patch the `m.room.power_levels` event 
+and set the required power level for enabling encryption to 150 which is higher than the room creator level (100), 
+effectively preventing anybody from enabling the encryption. 
+
 In addition the plugin will filter out events for enabling encryption on room based on the server:
   - deny_encryption_for_users_of: if the event sender is on the server in the list (i.e. @user:example.org)
   - deny_encryption_for_rooms_of: if the room is on the server in the list (i.e. !room:example.org)
@@ -37,4 +42,6 @@ loggers:
 
 ### Caveats
 
-This is not bullet-proof, a federated server that doesn't respect power levels may still allow users to enable encryption which will allow 3p users on other servers belonging to federation to freely use e2ee. This will create a divergence in room state and users on the server where this plugin is enabled won't be able to read encrypted messages - from their point of view the room will still be unencrypted.
+* This is not bullet-proof, a federated server that doesn't respect power levels may still allow users to enable encryption which will allow 3p users on other servers belonging to federation to freely use e2ee. This will create a divergence in room state and users on the server where this plugin is enabled won't be able to read encrypted messages - from their point of view the room will still be unencrypted.
+
+* The `patch_power_levels` option may be incompatible with certain servers because power levels higher than 100 are not documented in the Matrix spec.

--- a/matrix_e2ee_filter.py
+++ b/matrix_e2ee_filter.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 #     matrix_e2ee_filter:
 #         level: INFO
 
-def __patch_room_power_levels(room_power_levels, requester_user_id):
+def _patch_room_power_levels(room_power_levels, requester_user_id):
     DEFAULT_EVENT_ACL = {
         'm.room.name': 50,
         'm.room.power_levels': 100,
@@ -137,7 +137,7 @@ class EncryptedRoomFilter:
         # we need to mimic the server defaults. Defaults takes from here:
         # https://github.com/matrix-org/synapse/blob/develop/synapse/handlers/room.py#L1015-L1035
         if self.patch_power_levels:
-            initial_power_levels = __patch_room_power_levels(initial_power_levels, requester.user.to_string())
+            initial_power_levels = _patch_room_power_levels(initial_power_levels, requester.user.to_string())
 
         # Inject back the power level structure
         if initial_power_levels:

--- a/matrix_e2ee_filter.py
+++ b/matrix_e2ee_filter.py
@@ -7,6 +7,11 @@ logger = logging.getLogger(__name__)
 
 # Example config:
 #   Plugin will strip away encryption from newly created rooms.
+#
+# If `patch_power_levels` option is set to `True` the plugin will additionally patch the `m.room.power_levels` event 
+# and set the required power level for enabling encryption to 150 which is higher than the room creator level (100), 
+# effectively preventing anybody from enabling the encryption. Note that this may be incompatible with other servers.
+#
 #   In addition the plugin will filter out events for enabling encryption on room based on the server:
 #     - deny_encryption_for_users_of: if the event sender is on the server in the list (i.e. @user:example.org)
 #     - deny_encryption_for_rooms_of: if the room is on the server in the list (i.e. !room:example.org)
@@ -16,12 +21,60 @@ logger = logging.getLogger(__name__)
 #     config:
 #       deny_encryption_for_users_of: ['example.org']
 #       deny_encryption_for_rooms_of: ['example.org']
+#       patch_power_levels: False
 
 # You may also want to add the following to your logging config to debug the plugin:
 
 # loggers:
 #     matrix_e2ee_filter:
 #         level: INFO
+
+def __patch_room_power_levels(room_power_levels, requester_user_id):
+    DEFAULT_EVENT_ACL = {
+        'm.room.name': 50,
+        'm.room.power_levels': 100,
+        'm.room.history_visibility': 100,
+        'm.room.canonical_alias': 50,
+        'm.room.avatar': 50,
+        'm.room.tombstone': 100,
+        'm.room.server_acl': 100,
+        'm.room.encryption': 100
+    }
+    # Generate the new event if it's None or doesn't seem valid
+    if not room_power_levels or 'content' not in room_power_levels:
+        room_power_levels = {
+            'type': 'm.room.power_levels',
+            'sender': requester_user_id,
+            'content': {
+                'users': { requester_user_id: 100 },
+                'users_default': 0,
+                'events': DEFAULT_EVENT_ACL,
+                'events_default': 0,
+                'state_default': 50,
+                'ban': 50,
+                'kick': 50,
+                'redact': 50,
+                'invite': 0,
+                'historical': 100
+            }
+        }
+
+    content = room_power_levels['content']
+
+    # Figure out max user power level
+    if 'users' not in content:
+        content['users'] = { requester_user_id: 100 }
+        enc_power_level = 150
+    else:
+        enc_power_level = max(content['users'].values()) + 50
+
+    # Patch 'events' field if present, if not - use default and still patch
+    if 'events' not in content:
+        content['events'] = DEFAULT_EVENT_ACL
+
+    content['events']['m.room.encryption'] = enc_power_level
+
+    return room_power_levels
 
 
 class EncryptedRoomFilter:
@@ -30,6 +83,7 @@ class EncryptedRoomFilter:
         self.api = api
         self.deny_user_servers = config.get("deny_encryption_for_users_of", [])
         self.deny_room_servers = config.get("deny_encryption_for_rooms_of", [])
+        self.patch_power_levels = config.get("patch_power_levels", False)
         self.api.register_third_party_rules_callbacks(on_create_room = self.on_create_room,)
         self.api.register_spam_checker_callbacks(check_event_for_spam=self.check_event_for_spam,)
         logger.info('Registered custom rule filter: EncryptedRoomFilter')
@@ -63,9 +117,14 @@ class EncryptedRoomFilter:
         # Note that this still doesn't block users from enabling encryption at a later stage
 
         filtered_initial_state = []
+        initial_power_levels = None
         for event in request_content.get('initial_state', []):
             if event['type'] in ['m.room.encryption', 'm.room.power_levels']:
                 logger.info('Stripped "%s" from %s', event['type'], request_content.get('name', ''))
+
+                # If initial power levels event is present - store it for future use
+                if event['type'] == 'm.room.power_levels':
+                    initial_power_levels = event
             else:
                 filtered_initial_state.append(event)
 
@@ -77,31 +136,11 @@ class EncryptedRoomFilter:
         # Power levels are populated/generated later in the room creation flow. To make sure initial state is correct
         # we need to mimic the server defaults. Defaults takes from here:
         # https://github.com/matrix-org/synapse/blob/develop/synapse/handlers/room.py#L1015-L1035
-        requester_user_id = requester.user.to_string()
-        new_power_levels = {
-            'type': 'm.room.power_levels',
-            'sender': requester_user_id,
-            'content': {
-                'users': { requester_user_id: 100 },
-                'users_default': 0,
-                'events': {
-                    'm.room.name': 50,
-                    'm.room.power_levels': 100,
-                    'm.room.history_visibility': 100,
-                    'm.room.canonical_alias': 50,
-                    'm.room.avatar': 50,
-                    'm.room.tombstone': 100,
-                    'm.room.server_acl': 100,
-                    'm.room.encryption': 150
-                },
-                'events_default': 0,
-                'state_default': 50,
-                'ban': 50,
-                'kick': 50,
-                'redact': 50,
-                'invite': 0,
-                'historical': 100
-            }
-        }
-        filtered_initial_state.append(new_power_levels)
+        if self.patch_power_levels:
+            initial_power_levels = __patch_room_power_levels(initial_power_levels, requester.user.to_string())
+
+        # Inject back the power level structure
+        if initial_power_levels:
+            filtered_initial_state.append(initial_power_levels)
+
         request_content['initial_state'] = filtered_initial_state


### PR DESCRIPTION
Addresses some of the #5:
 * Adds a configuration setting `patch_power_levels` (default disabled)
 * Fixes the docs mentioning the option, how it works and why it may be dangerous
 * Patch the event instead of owerwriting it if already present